### PR TITLE
修复获取分数排序混乱的问题

### DIFF
--- a/SourcePackages/pandalearning.py
+++ b/SourcePackages/pandalearning.py
@@ -67,7 +67,7 @@ def article(cookies, a_log, each):
                 a_num = 6 - each[0]
                 for i in range(a_log, a_log + a_num):
                     driver_article.get_url(links[i])
-                    readarticle_time = 60+random.randint(5, 15)
+                    readarticle_time = 60 + random.randint(5, 15)
                     for j in range(readarticle_time):
                         if random.random() > 0.5:
                             driver_article.go_js('window.scrollTo(0, document.body.scrollHeight/120*{})'.format(j))
@@ -87,7 +87,7 @@ def article(cookies, a_log, each):
         while True:
             if each[3] < 6 and try_count < 10:
                 num_time = 60
-                driver_article.get_url(links[a_log-1])
+                driver_article.get_url(links[a_log - 1])
                 
                 remaining = (6 - each[3]) * 1 * num_time
                 for i in range(remaining):
@@ -127,7 +127,7 @@ def video(cookies, v_log, each):
                 v_num = 6 - each[1]
                 for i in range(v_log, v_log + v_num):
                     driver_video.get_url(links[i])
-                    watchvideo_time = 60+random.randint(5, 15)
+                    watchvideo_time = 60 + random.randint(5, 15)
                     for j in range(watchvideo_time):
                         if random.random() > 0.5:
                             driver_video.go_js('window.scrollTo(0, document.body.scrollHeight/180*{})'.format(j))
@@ -147,7 +147,7 @@ def video(cookies, v_log, each):
         while True:
             if each[4] < 6 and try_count < 10:
                 num_time = 60
-                driver_video.get_url(links[v_log-1])
+                driver_video.get_url(links[v_log - 1])
                 remaining = (6 - each[4]) * 1 * num_time
                 for i in range(remaining):
                     if random.random() > 0.5:

--- a/SourcePackages/pandalearning.py
+++ b/SourcePackages/pandalearning.py
@@ -67,7 +67,6 @@ def article(cookies, a_log, each):
                 a_num = 6 - each[0]
                 for i in range(a_log, a_log + a_num):
                     driver_article.get_url(links[i])
-                    time.sleep(random.randint(5, 15))
                     readarticle_time = 60+random.randint(5, 15)
                     for j in range(readarticle_time):
                         if random.random() > 0.5:
@@ -89,7 +88,6 @@ def article(cookies, a_log, each):
             if each[3] < 6 and try_count < 10:
                 num_time = 60
                 driver_article.get_url(links[a_log-1])
-                time.sleep(random.randint(5, 15))
                 
                 remaining = (6 - each[3]) * 1 * num_time
                 for i in range(remaining):
@@ -129,7 +127,6 @@ def video(cookies, v_log, each):
                 v_num = 6 - each[1]
                 for i in range(v_log, v_log + v_num):
                     driver_video.get_url(links[i])
-                    time.sleep(random.randint(5, 15))
                     watchvideo_time = 60+random.randint(5, 15)
                     for j in range(watchvideo_time):
                         if random.random() > 0.5:
@@ -151,7 +148,6 @@ def video(cookies, v_log, each):
             if each[4] < 6 and try_count < 10:
                 num_time = 60
                 driver_video.get_url(links[v_log-1])
-                time.sleep(random.randint(5, 15))
                 remaining = (6 - each[4]) * 1 * num_time
                 for i in range(remaining):
                     if random.random() > 0.5:

--- a/SourcePackages/pandalearning.py
+++ b/SourcePackages/pandalearning.py
@@ -88,7 +88,6 @@ def article(cookies, a_log, each):
             if each[3] < 6 and try_count < 10:
                 num_time = 60
                 driver_article.get_url(links[a_log - 1])
-                
                 remaining = (6 - each[3]) * 1 * num_time
                 for i in range(remaining):
                     if random.random() > 0.5:

--- a/SourcePackages/pandalearning.py
+++ b/SourcePackages/pandalearning.py
@@ -61,16 +61,18 @@ def article(cookies, a_log, each):
         driver_article.set_cookies(cookies)
         links = get_links.get_article_links()
         try_count = 0
+        readarticle_time = 0
         while True:
             if each[0] < 6 and try_count < 10:
                 a_num = 6 - each[0]
                 for i in range(a_log, a_log + a_num):
                     driver_article.get_url(links[i])
                     time.sleep(random.randint(5, 15))
-                    for j in range(120):
+                    readarticle_time = 60+random.randint(5, 15)
+                    for j in range(readarticle_time):
                         if random.random() > 0.5:
                             driver_article.go_js('window.scrollTo(0, document.body.scrollHeight/120*{})'.format(j))
-                        print("\r文章学习中，文章剩余{}篇,本篇剩余时间{}秒".format(a_log + a_num - i, 120 - j), end="")
+                        print("\r文章学习中，文章剩余{}篇,本篇剩余时间{}秒".format(a_log + a_num - i, readarticle_time - j), end="")
                         time.sleep(1)
                     driver_article.go_js('window.scrollTo(0, document.body.scrollHeight)')
                     total, each = show_score(cookies)
@@ -88,14 +90,15 @@ def article(cookies, a_log, each):
                 num_time = 60
                 driver_article.get_url(links[a_log-1])
                 time.sleep(random.randint(5, 15))
-                remaining = (6 - each[3]) * 4 * num_time
+                
+                remaining = (6 - each[3]) * 1 * num_time
                 for i in range(remaining):
                     if random.random() > 0.5:
                         driver_article.go_js(
                             'window.scrollTo(0, document.body.scrollHeight/{}*{})'.format(remaining, i))
                     print("\r文章时长学习中，文章总时长剩余{}秒".format(remaining - i), end="")
                     time.sleep(1)
-                    if i % (120) == 0 and i != remaining:
+                    if i % (60) == 0 and i != remaining:
                         total, each = show_score(cookies)
                         if each[3] >= 6:
                             print("检测到文章时长分数已满,退出学习")
@@ -120,16 +123,18 @@ def video(cookies, v_log, each):
         driver_video.set_cookies(cookies)
         links = get_links.get_video_links()
         try_count = 0
+        watchvideo_time = 0
         while True:
             if each[1] < 6 and try_count < 10:
                 v_num = 6 - each[1]
                 for i in range(v_log, v_log + v_num):
                     driver_video.get_url(links[i])
                     time.sleep(random.randint(5, 15))
-                    for j in range(180):
+                    watchvideo_time = 60+random.randint(5, 15)
+                    for j in range(watchvideo_time):
                         if random.random() > 0.5:
                             driver_video.go_js('window.scrollTo(0, document.body.scrollHeight/180*{})'.format(j))
-                        print("\r视频学习中，视频剩余{}个,本次剩余时间{}秒".format(v_log + v_num - i, 180 - j), end="")
+                        print("\r视频学习中，视频剩余{}个,本次剩余时间{}秒".format(v_log + v_num - i, watchvideo_time - j), end="")
                         time.sleep(1)
                     driver_video.go_js('window.scrollTo(0, document.body.scrollHeight)')
                     total, each = show_score(cookies)
@@ -147,14 +152,14 @@ def video(cookies, v_log, each):
                 num_time = 60
                 driver_video.get_url(links[v_log-1])
                 time.sleep(random.randint(5, 15))
-                remaining = (6 - each[4]) * 3 * num_time
+                remaining = (6 - each[4]) * 1 * num_time
                 for i in range(remaining):
                     if random.random() > 0.5:
                         driver_video.go_js(
                             'window.scrollTo(0, document.body.scrollHeight/{}*{})'.format(remaining, i))
                     print("\r视频学习中，视频总时长剩余{}秒".format(remaining - i), end="")
                     time.sleep(1)
-                    if i % (180) == 0 and i != remaining:
+                    if i % (60) == 0 and i != remaining:
                         total, each = show_score(cookies)
                         if each[4] >= 6:
                             print("检测到视频时长分数已满,退出学习")

--- a/SourcePackages/pdlearn/score.py
+++ b/SourcePackages/pdlearn/score.py
@@ -9,13 +9,23 @@ def get_score(cookies):
         for cookie in cookies:
             jar.set(cookie['name'], cookie['value'])
         total = requests.get("https://pc-api.xuexi.cn/open/api/score/get", cookies=jar,
-                            headers={'Cache-Control': 'no-cache'}).content.decode("utf8")
+                             headers={'Cache-Control': 'no-cache'}).content.decode("utf8")
         total = int(json.loads(total, encoding="utf8")["data"]["score"])
-        each = requests.get("https://pc-api.xuexi.cn/open/api/score/today/queryrate", cookies=jar,
+        each1 = requests.get("https://pc-api.xuexi.cn/open/api/score/today/queryrate", cookies=jar,
                             headers={'Cache-Control': 'no-cache'}).content.decode(
             "utf8")
-        each = json.loads(each, encoding="utf8")["data"]["dayScoreDtos"]
-        each = [int(i["currentScore"]) for i in each if i["ruleId"] in [1, 2, 9, 1002, 1003, 6, 5, 4]]
+        each1 = json.loads(each1, encoding="utf8")["data"]["dayScoreDtos"]
+        each1 = [int(i["currentScore"]) for i in each1 if i["ruleId"] in [1, 2, 9, 1002, 1003,6, 5, 4]]
+        each = [0,0,0,0,0,0,0,0]
+        each[0]=each1[0]
+        each[1]=each1[1]
+        each[2]=each1[5]
+        each[3]=each1[6]
+        each[4]=each1[7]
+        each[5]=each1[4]
+        each[6]=each1[3]
+        each[7]=each1[2]
+        print(each)
         return total, each
     except:
         print("=" * 120)

--- a/SourcePackages/pdlearn/score.py
+++ b/SourcePackages/pdlearn/score.py
@@ -9,13 +9,13 @@ def get_score(cookies):
         for cookie in cookies:
             jar.set(cookie['name'], cookie['value'])
         total = requests.get("https://pc-api.xuexi.cn/open/api/score/get", cookies=jar,
-                             headers={'Cache-Control': 'no-cache'}).content.decode("utf8")
+                            headers={'Cache-Control': 'no-cache'}).content.decode("utf8")
         total = int(json.loads(total, encoding="utf8")["data"]["score"])
         each = requests.get("https://pc-api.xuexi.cn/open/api/score/today/queryrate", cookies=jar,
                             headers={'Cache-Control': 'no-cache'}).content.decode(
             "utf8")
         each = json.loads(each, encoding="utf8")["data"]["dayScoreDtos"]
-        each = [int(i["currentScore"]) for i in each if i["ruleId"] in [1, 2, 9, 1002, 1003,6, 5, 4]]
+        each = [int(i["currentScore"]) for i in each if i["ruleId"] in [1, 2, 9, 1002, 1003, 6, 5, 4]]
         return total, each
     except:
         print("=" * 120)

--- a/SourcePackages/pdlearn/score.py
+++ b/SourcePackages/pdlearn/score.py
@@ -11,21 +11,11 @@ def get_score(cookies):
         total = requests.get("https://pc-api.xuexi.cn/open/api/score/get", cookies=jar,
                              headers={'Cache-Control': 'no-cache'}).content.decode("utf8")
         total = int(json.loads(total, encoding="utf8")["data"]["score"])
-        each1 = requests.get("https://pc-api.xuexi.cn/open/api/score/today/queryrate", cookies=jar,
+        each = requests.get("https://pc-api.xuexi.cn/open/api/score/today/queryrate", cookies=jar,
                             headers={'Cache-Control': 'no-cache'}).content.decode(
             "utf8")
-        each1 = json.loads(each1, encoding="utf8")["data"]["dayScoreDtos"]
-        each1 = [int(i["currentScore"]) for i in each1 if i["ruleId"] in [1, 2, 9, 1002, 1003,6, 5, 4]]
-        each = [0,0,0,0,0,0,0,0]
-        each[0]=each1[0]
-        each[1]=each1[1]
-        each[2]=each1[5]
-        each[3]=each1[6]
-        each[4]=each1[7]
-        each[5]=each1[4]
-        each[6]=each1[3]
-        each[7]=each1[2]
-        print(each)
+        each = json.loads(each, encoding="utf8")["data"]["dayScoreDtos"]
+        each = [int(i["currentScore"]) for i in each if i["ruleId"] in [1, 2, 9, 1002, 1003,6, 5, 4]]
         return total, each
     except:
         print("=" * 120)

--- a/SourcePackages/pdlearn/score.py
+++ b/SourcePackages/pdlearn/score.py
@@ -8,12 +8,24 @@ def get_score(cookies):
         jar = RequestsCookieJar()
         for cookie in cookies:
             jar.set(cookie['name'], cookie['value'])
-        total = requests.get("https://pc-api.xuexi.cn/open/api/score/get", cookies=jar).content.decode("utf8")
+        total = requests.get("https://pc-api.xuexi.cn/open/api/score/get", cookies=jar,
+                             headers={'Cache-Control': 'no-cache'}).content.decode("utf8")
         total = int(json.loads(total, encoding="utf8")["data"]["score"])
-        each = requests.get("https://pc-api.xuexi.cn/open/api/score/today/queryrate", cookies=jar).content.decode(
+        each1 = requests.get("https://pc-api.xuexi.cn/open/api/score/today/queryrate", cookies=jar,
+                            headers={'Cache-Control': 'no-cache'}).content.decode(
             "utf8")
-        each = json.loads(each, encoding="utf8")["data"]["dayScoreDtos"]
-        each = [int(i["currentScore"]) for i in each if i["ruleId"] in [1, 2, 9, 1002, 1003]]
+        each1 = json.loads(each1, encoding="utf8")["data"]["dayScoreDtos"]
+        each1 = [int(i["currentScore"]) for i in each1 if i["ruleId"] in [1, 2, 9, 1002, 1003,6, 5, 4]]
+        each = [0,0,0,0,0,0,0,0]
+        each[0]=each1[0]
+        each[1]=each1[1]
+        each[2]=each1[5]
+        each[3]=each1[6]
+        each[4]=each1[7]
+        each[5]=each1[4]
+        each[6]=each1[3]
+        each[7]=each1[2]
+        print(each)
         return total, each
     except:
         print("=" * 120)

--- a/SourcePackages/pdlearn/version.py
+++ b/SourcePackages/pdlearn/version.py
@@ -3,7 +3,7 @@ import requests
 
 def up_info():
     print("\n正在联网获取更新信息...")
-    __Version = "v20200907"
+    __Version = "v20200907-2"
     __INFO = "TechXueXi最新下载地址为 https://github.com/TechXueXi/TechXueXi"
     try:
         updata_log = requests.get(

--- a/SourcePackages/pdlearn/version.py
+++ b/SourcePackages/pdlearn/version.py
@@ -3,7 +3,7 @@ import requests
 
 def up_info():
     print("\n正在联网获取更新信息...")
-    __Version = "v20200814"
+    __Version = "v20200907"
     __INFO = "TechXueXi最新下载地址为 https://github.com/TechXueXi/TechXueXi"
     try:
         updata_log = requests.get(

--- a/SourcePackages/pdlearn/version.py
+++ b/SourcePackages/pdlearn/version.py
@@ -3,7 +3,7 @@ import requests
 
 def up_info():
     print("\n正在联网获取更新信息...")
-    __Version = "v20200907-2"
+    __Version = "v20200908"
     __INFO = "TechXueXi最新下载地址为 https://github.com/TechXueXi/TechXueXi"
     try:
         updata_log = requests.get(


### PR DESCRIPTION
经本人多次实验发现，score.py文件中each = [int(i["currentScore"]) for i in each1 if i["ruleId"] in [1, 2, 9, 1002, 1003,6, 5, 4]]的写法并不会让each数组从ruleId从1,2,9,1002,1003,6,5,4这样排序，系统仍会按照1,2,4,5,6,9,1002,1003的顺序排序，这就会导致获取的分数混乱，（原未加答题功能前按1,2,9,1002,1003排序正好是按数字大小排序，所以未出BUG，现加答题功能后获取ruleId的值排序会混乱），于是建了个新数组each1存乱序数据，用each存排好序的数据，亲测顺序正确。奈何本人不怎么懂python，只能用这种笨办法修bug了，各位有什么高明的写法也可以写进去，这里只是指出bug原理。（本人功力不扎实，测了几次才测出原因）