### PR TITLE
改进：each数不清楚的问题、打印"="数量、命令行选项顺序、“爱党爱国”、每周答题专项答题选择最旧的题

### DIFF
--- a/SourcePackages/pandalearning.py
+++ b/SourcePackages/pandalearning.py
@@ -613,9 +613,9 @@ if __name__ == '__main__':
 https://996.icu/ 或 https://github.com/996icu/996.ICU/blob/master/README_CN.md
 TechXueXi 现支持以下模式（答题时请值守电脑旁处理少部分不正常的题目）：
     1 文章+视频
-    2 每日答题+文章+视频
+    2 文章+视频+每日答题
       （可以根据当日已得做题积分，决定是否做题）
-    3 每日答题+每周答题+专项答题+文章+视频
+    3 文章+视频+每日答题+每周答题+专项答题
       （可以根据当日已得做题积分，及是否有可得分套题，决定是否做题）
 ''',"=" * 60)
     TechXueXi_mode = input("请选择模式（输入对应数字）并回车： ")
@@ -628,6 +628,13 @@ TechXueXi 现支持以下模式（答题时请值守电脑旁处理少部分不�
     total, scores = show_score(cookies)
     nohead, lock, stime = get_argv()
 
+    article_thread = threads.MyThread("文章学习", article, cookies, a_log, scores, lock=lock)
+    video_thread = threads.MyThread("视频学习", video, cookies, v_log, scores, lock=lock)
+    article_thread.start()
+    video_thread.start()
+    article_thread.join()
+    video_thread.join()
+
     if TechXueXi_mode in ["2"]:
         print('开始每日答题……')
         daily(cookies, d_log, scores)
@@ -637,11 +644,5 @@ TechXueXi 现支持以下模式（答题时请值守电脑旁处理少部分不�
         print('开始专项答题……')
         zhuanxiang(cookies, d_log, scores)
 
-    article_thread = threads.MyThread("文章学习", article, cookies, a_log, scores, lock=lock)
-    video_thread = threads.MyThread("视频学习", video, cookies, v_log, scores, lock=lock)
-    article_thread.start()
-    video_thread.start()
-    article_thread.join()
-    video_thread.join()
     print("总计用时" + str(int(time.time() - start_time) / 60) + "分钟")
     user.shutdown(stime)

--- a/SourcePackages/pandalearning.py
+++ b/SourcePackages/pandalearning.py
@@ -328,6 +328,7 @@ def weekly(cookies, d_log, scores):
             driver_weekly.get_url('https://pc.xuexi.cn/points/my-points.html')
             driver_weekly.click_xpath('//*[@id="app"]/div/div[2]/div/div[3]/div[2]/div[6]/div[2]/div[2]/div')
             time.sleep(2)
+#<<<<<<< fix-some-bugs
 #           flag = 1
 #           for tem in range(0, 40):
 #               for tem2 in range(0, 5):
@@ -354,6 +355,44 @@ def weekly(cookies, d_log, scores):
                     break
             toclick.click()
             while scores["weekly"] < 5 and try_count < 10:
+'''                
+=======
+            flag = 1
+            page_num = 1
+            last_page = int(driver_weekly.driver.find_element_by_xpath('//*[@id="app"]/div/div[2]/div/div[5]/ul/li[last()-1]/a').text)
+            while page_num < last_page and flag == 1:
+                print('进入每周答题第'+ str(page_num) +'页')
+                all_month = len(driver_weekly.driver.find_elements_by_class_name('month'))
+                cur_month = 1
+                for tem in range(0, all_month):
+                    for tem2 in range(0, 6):
+                        if flag == 0:
+                            break
+                        try:
+                            temword = driver_weekly.driver.find_element_by_xpath(
+                                '//*[@id="app"]/div/div[2]/div/div[4]/div/div[' + str(tem + 1) + ']/div[2]/div[' + str(
+                                    tem2 + 1) + ']/button').text
+                        except:
+                            temword = ''
+                            if all_month == cur_month:
+                                driver_weekly.click_xpath(
+                                        '//*[@id="app"]/div/div[2]/div/div[5]/ul/li[' + str(page_num + 2) + ']')
+                                print('切换至下一页')
+                                page_num += 1
+                                time.sleep(2)
+                            cur_month += 1
+                            break
+                        name_list = ["开始答题", "继续答题"]
+                        if flag == 1 and (any(name in temword for name in name_list)):
+                            driver_weekly.click_xpath(
+                                '//*[@id="app"]/div/div[2]/div/div[4]/div/div[' + str(tem + 1) + ']/div[2]/div[' + str(
+                                    tem2 + 1) + ']/button')
+                            flag = 0
+                        elif '重新答题' in temword:
+                            continue
+            while each[6] < 5 and try_count < 10:
+>>>>>>> dev
+'''
                 try:
                     category = driver_weekly.xpath_getText(
                         '//*[@id="app"]/div/div[2]/div/div[4]/div[1]/div[1]')  # get_attribute("name")

--- a/SourcePackages/pandalearning.py
+++ b/SourcePackages/pandalearning.py
@@ -1,4 +1,7 @@
+import os
+import sys
 import time
+from time import sleep
 from sys import argv
 import random
 from pdlearn import version
@@ -49,15 +52,15 @@ def get_argv():
 
 
 def show_score(cookies):
-    total, each = score.get_score(cookies)
-    print("当前学习总积分：" + str(total))
-    print("阅读文章:{}/6,观看视频:{}/6,登陆:{}/1,文章时长:{}/6,视频时长:{}/6,每日答题:{}/6,每周答题:{}/5,专项答题:{}/10".format(*each))
-    # print("阅读文章:",each[0],"/6,观看视频:",each[1],"/6,登陆:",each[2],"/1,文章时长:",each[3],"/6,视频时长:",each[4],"/6,每日答题:",each[5],"/6,每周答题:",each[6],"/5,专项答题:",each[7],"/10")
-    return total, each
+    total, scores = score.get_score(cookies)
+    print("当前学习总积分：" + str(total) + "\t" + "今日得分：" + str(scores["today"]))
+    # print("阅读文章:{}/6,观看视频:{}/6,登陆:{}/1,文章时长:{}/6,视频时长:{}/6,每日答题:{}/5,每周答题:{}/5,专项答题:{}/10".format(*ea_ch))
+    print("阅读文章:",scores["article_num"],"/6,观看视频:",scores["video_num"],"/6,登陆:",scores["login"],"/1,文章时长:",scores["article_time"],"/6,视频时长:",scores["video_time"],"/6,每日答题:",scores["daily"],"/6,每周答题:",scores["weekly"],"/5,专项答题:",scores["zhuanxiang"],"/10")
+    return total, scores
 
 
-def article(cookies, a_log, each):
-    if each[0] < 6 or each[3] < 8:
+def article(cookies, a_log, scores):
+    if scores["article_num"] < 6 or scores["article_time"] < 6:
         driver_article = mydriver.Mydriver(nohead=nohead)
         driver_article.get_url("https://www.xuexi.cn/notFound.html")
         driver_article.set_cookies(cookies)
@@ -65,8 +68,8 @@ def article(cookies, a_log, each):
         try_count = 0
         readarticle_time = 0
         while True:
-            if each[0] < 6 and try_count < 10:
-                a_num = 6 - each[0]
+            if scores["article_num"] < 6 and try_count < 10:
+                a_num = 6 - scores["article_num"]
                 for i in range(a_log, a_log + a_num):
                     driver_article.get_url(links[i])
                     readarticle_time = 60 + random.randint(5, 15)
@@ -76,8 +79,8 @@ def article(cookies, a_log, each):
                         print("\r文章学习中，文章剩余{}篇,本篇剩余时间{}秒".format(a_log + a_num - i, readarticle_time - j), end="")
                         time.sleep(1)
                     driver_article.go_js('window.scrollTo(0, document.body.scrollHeight)')
-                    total, each = show_score(cookies)
-                    if each[0] >= 6:
+                    total, scores = show_score(cookies)
+                    if scores["article_num"] >= 6:
                         print("检测到文章数量分数已满,退出学习")
                         break
                 a_log += a_num
@@ -87,10 +90,10 @@ def article(cookies, a_log, each):
                 break
         try_count = 0
         while True:
-            if each[3] < 6 and try_count < 10:
+            if scores["article_time"] < 6 and try_count < 10:
                 num_time = 60
                 driver_article.get_url(links[a_log - 1])
-                remaining = (6 - each[3]) * 1 * num_time
+                remaining = (6 - scores["article_time"]) * 1 * num_time
                 for i in range(remaining):
                     if random.random() > 0.5:
                         driver_article.go_js(
@@ -98,12 +101,12 @@ def article(cookies, a_log, each):
                     print("\r文章时长学习中，文章总时长剩余{}秒".format(remaining - i), end="")
                     time.sleep(1)
                     if i % (60) == 0 and i != remaining:
-                        total, each = show_score(cookies)
-                        if each[3] >= 6:
+                        total, scores = show_score(cookies)
+                        if scores["article_time"] >= 6:
                             print("检测到文章时长分数已满,退出学习")
                             break
                 driver_article.go_js('window.scrollTo(0, document.body.scrollHeight)')
-                total, each = show_score(cookies)
+                total, scores = show_score(cookies)
             else:
                 break
         if try_count < 10:
@@ -115,8 +118,8 @@ def article(cookies, a_log, each):
         print("文章之前学完了")
 
 
-def video(cookies, v_log, each):
-    if each[1] < 6 or each[4] < 10:
+def video(cookies, v_log, scores):
+    if scores["video_num"] < 6 or scores["video_time"] < 10:
         driver_video = mydriver.Mydriver(nohead=nohead)
         driver_video.get_url("https://www.xuexi.cn/notFound.html")
         driver_video.set_cookies(cookies)
@@ -124,8 +127,8 @@ def video(cookies, v_log, each):
         try_count = 0
         watchvideo_time = 0
         while True:
-            if each[1] < 6 and try_count < 10:
-                v_num = 6 - each[1]
+            if scores["video_num"] < 6 and try_count < 10:
+                v_num = 6 - scores["video_num"]
                 for i in range(v_log, v_log + v_num):
                     driver_video.get_url(links[i])
                     watchvideo_time = 60 + random.randint(5, 15)
@@ -135,8 +138,8 @@ def video(cookies, v_log, each):
                         print("\r视频学习中，视频剩余{}个,本次剩余时间{}秒".format(v_log + v_num - i, watchvideo_time - j), end="")
                         time.sleep(1)
                     driver_video.go_js('window.scrollTo(0, document.body.scrollHeight)')
-                    total, each = show_score(cookies)
-                    if each[1] >= 6:
+                    total, scores = show_score(cookies)
+                    if scores["video_num"] >= 6:
                         print("检测到视频数量分数已满,退出学习")
                         break
                 v_log += v_num
@@ -146,10 +149,10 @@ def video(cookies, v_log, each):
                 break
         try_count = 0
         while True:
-            if each[4] < 6 and try_count < 10:
+            if scores["video_time"] < 6 and try_count < 10:
                 num_time = 60
                 driver_video.get_url(links[v_log - 1])
-                remaining = (6 - each[4]) * 1 * num_time
+                remaining = (6 - scores["video_time"]) * 1 * num_time
                 for i in range(remaining):
                     if random.random() > 0.5:
                         driver_video.go_js(
@@ -157,12 +160,12 @@ def video(cookies, v_log, each):
                     print("\r视频学习中，视频总时长剩余{}秒".format(remaining - i), end="")
                     time.sleep(1)
                     if i % (60) == 0 and i != remaining:
-                        total, each = show_score(cookies)
-                        if each[4] >= 6:
+                        total, scores = show_score(cookies)
+                        if scores["video_time"] >= 6:
                             print("检测到视频时长分数已满,退出学习")
                             break
                 driver_video.go_js('window.scrollTo(0, document.body.scrollHeight)')
-                total, each = show_score(cookies)
+                total, scores = show_score(cookies)
             else:
                 break
         if try_count < 10:
@@ -180,8 +183,8 @@ def check_delay():
     time.sleep(delay_time)
 
 
-def daily(cookies, d_log, each):
-    if each[5] < 6:
+def daily(cookies, d_log, scores):
+    if scores["daily"] < 6:
         # driver_daily = mydriver.Mydriver(nohead=nohead)  time.sleep(random.randint(5, 15))
         driver_daily = mydriver.Mydriver(nohead=False)
         driver_daily.driver.maximize_window()
@@ -192,12 +195,12 @@ def daily(cookies, d_log, each):
         driver_daily.set_cookies(cookies)
         try_count = 0
 
-        if each[5] < 6:
-            d_num = 6 - each[5]
+        if scores["daily"] < 6:
+            d_num = 6 - scores["daily"]
             letters = list("ABCDEFGHIJKLMN")
             driver_daily.get_url('https://pc.xuexi.cn/points/my-points.html')
             driver_daily.click_xpath('//*[@id="app"]/div/div[2]/div/div[3]/div[2]/div[5]/div[2]/div[2]/div')
-            while each[5] < 6:
+            while scores["daily"] < 6:
                 try:
                     category = driver_daily.xpath_getText(
                         '//*[@id="app"]/div/div[2]/div/div[4]/div[1]/div[1]')  # get_attribute("name")
@@ -289,8 +292,8 @@ def daily(cookies, d_log, each):
                     time.sleep(1)
                 d_log += d_num
 
-            total, each = show_score(cookies)
-            if each[5] >= 6:
+            total, scores = show_score(cookies)
+            if scores["daily"] >= 5:
                 print("检测到每日答题分数已满,退出学习")
                 driver_daily.quit()
         else:
@@ -305,8 +308,8 @@ def daily(cookies, d_log, each):
         print("每日答题之前学完了")
 
 
-def weekly(cookies, d_log, each):
-    if each[6] < 5:
+def weekly(cookies, d_log, scores):
+    if scores["weekly"] < 5:
         # driver_weekly = mydriver.Mydriver(nohead=nohead)  time.sleep(random.randint(5, 15))
         driver_weekly = mydriver.Mydriver(nohead=False)
         driver_weekly.driver.maximize_window()
@@ -317,28 +320,38 @@ def weekly(cookies, d_log, each):
         driver_weekly.set_cookies(cookies)
         try_count = 0
 
-        if each[6] < 5:
-            d_num = 6 - each[5]
+        if scores["weekly"] < 5:
+            d_num = 6 - scores["weekly"]
             letters = list("ABCDEFGHIJKLMN")
             driver_weekly.get_url('https://pc.xuexi.cn/points/my-points.html')
             driver_weekly.click_xpath('//*[@id="app"]/div/div[2]/div/div[3]/div[2]/div[6]/div[2]/div[2]/div')
             time.sleep(2)
-            flag = 1
-            for tem in range(0, 40):
-                for tem2 in range(0, 5):
-                    try:
-                        temword = driver_weekly.driver.find_element_by_xpath(
-                            '//*[@id="app"]/div/div[2]/div/div[4]/div/div[' + str(tem + 1) + ']/div[2]/div[' + str(
-                                tem2 + 1) + ']/button').text
-                    except:
-                        temword = ''
-                    name_list = ["开始答题", "继续答题"]
-                    if flag == 1 and (any(name in temword for name in name_list)):
-                        driver_weekly.click_xpath(
-                            '//*[@id="app"]/div/div[2]/div/div[4]/div/div[' + str(tem + 1) + ']/div[2]/div[' + str(
-                                tem2 + 1) + ']/button')
-                        flag = 0
-            while each[6] < 5 and try_count < 10:
+#           flag = 1
+#           for tem in range(0, 40):
+#               for tem2 in range(0, 5):
+#                   try:
+#                       temword = driver_weekly.driver.find_element_by_xpath(
+#                           '//*[@id="app"]/div/div[2]/div/div[4]/div/div[' + str(tem + 1) + ']/div[2]/div[' + str(
+#                               tem2 + 1) + ']/button').text
+#                   except:
+#                       temword = ''
+#                   name_list = ["开始答题", "继续答题"]
+#                   if flag == 1 and (any(name in temword for name in name_list)):
+#                       driver_weekly.click_xpath(
+#                           '//*[@id="app"]/div/div[2]/div/div[4]/div/div[' + str(tem + 1) + ']/div[2]/div[' + str(
+#                               tem2 + 1) + ']/button')
+#                       flag = 0
+            dati = driver_weekly.driver.find_elements_by_css_selector("#app .month .week button")
+            toclick = dati
+            for i in range(len(dati)-1,0,-1):
+                j=dati[i]
+                if("重新" in j.text):
+                    continue
+                else:
+                    toclick = j
+                    break
+            toclick.click()
+            while scores["weekly"] < 5 and try_count < 10:
                 try:
                     category = driver_weekly.xpath_getText(
                         '//*[@id="app"]/div/div[2]/div/div[4]/div[1]/div[1]')  # get_attribute("name")
@@ -430,8 +443,8 @@ def weekly(cookies, d_log, each):
                     time.sleep(1)
                 d_log += d_num
 
-            total, each = show_score(cookies)
-            if each[6] >= 5:
+            total, scores = show_score(cookies)
+            if scores["weekly"] >= 5:
                 print("检测到每周答题分数已满,退出学习")
                 driver_weekly.quit()
         else:
@@ -446,8 +459,8 @@ def weekly(cookies, d_log, each):
         print("每周答题之前学完了")
 
 
-def zhuanxiang(cookies, d_log, each):
-    if each[7] < 10:
+def zhuanxiang(cookies, d_log, scores):
+    if scores["zhuanxiang"] < 10:
         # driver_zhuanxiang = mydriver.Mydriver(nohead=nohead)  time.sleep(random.randint(5, 15))
         driver_zhuanxiang = mydriver.Mydriver(nohead=False)
         driver_zhuanxiang.driver.maximize_window()
@@ -458,24 +471,26 @@ def zhuanxiang(cookies, d_log, each):
         driver_zhuanxiang.set_cookies(cookies)
         try_count = 0
 
-        if each[7] < 10:
-            d_num = 10 - each[5]
+        if scores["zhuanxiang"] < 10:
+            d_num = 10 - scores["zhuanxiang"]
             letters = list("ABCDEFGHIJKLMN")
             driver_zhuanxiang.get_url('https://pc.xuexi.cn/points/my-points.html')
             driver_zhuanxiang.click_xpath('//*[@id="app"]/div/div[2]/div/div[3]/div[2]/div[7]/div[2]/div[2]/div')
             time.sleep(2)
-            for tem in range(0, 40):
-                try:
-                    temword = driver_zhuanxiang.driver.find_element_by_xpath(
-                        '//*[@id="app"]/div/div[2]/div/div[4]/div/div/div/div[' + str(tem + 1) + ']/div[2]/button').text
-                except:
-                    temword = ''
-                name_list = ["开始答题", "继续答题"]  # , "重新答题"
-                if (any(name in temword for name in name_list)):
-                    driver_zhuanxiang.click_xpath(
-                        '//*[@id="app"]/div/div[2]/div/div[4]/div/div/div/div[' + str(tem + 1) + ']/div[2]/button')
-                    break
-            while each[7] < 10:
+#           for tem in range(0, 40):
+#               try:
+#                   temword = driver_zhuanxiang.driver.find_element_by_xpath(
+#                       '//*[@id="app"]/div/div[2]/div/div[4]/div/div/div/div[' + str(tem + 1) + ']/div[2]/button').text
+#               except:
+#                   temword = ''
+#               name_list = ["开始答题", "继续答题"]  # , "重新答题"
+#               if (any(name in temword for name in name_list)):
+#                   driver_zhuanxiang.click_xpath(
+#                       '//*[@id="app"]/div/div[2]/div/div[4]/div/div/div/div[' + str(tem + 1) + ']/div[2]/button')
+#                   break
+            dati = driver_zhuanxiang.driver.find_elements_by_css_selector("#app .items .item button")
+            dati[-1].click()
+            while scores["zhuanxiang"] < 10:
                 try:
                     category = driver_zhuanxiang.xpath_getText(
                         '//*[@id="app"]/div/div[2]/div/div[6]/div[1]/div[1]')  # get_attribute("name")
@@ -567,8 +582,8 @@ def zhuanxiang(cookies, d_log, each):
                     time.sleep(1)
                 d_log += d_num
 
-            total, each = show_score(cookies)
-            if each[6] >= 5:
+            total, scores = show_score(cookies)
+            if scores["zhuanxiang"] >= 5:
                 print("检测到专项答题分数已满,退出学习")
                 driver_zhuanxiang.quit()
         else:
@@ -587,22 +602,22 @@ if __name__ == '__main__':
     #  0 读取版本信息
     start_time = time.time()
 
-    print("=" * 120,'''
+    print("=" * 60,'''
     科技强国官方网站：https://techxuexi.js.org
     Github地址：https://github.com/TechXueXi
 使用本项目，必须接受以下内容，否则请立即退出：
-    - TechXueXi 仅额外提供给“热爱党国”且“工作学业繁重”的人
+    - TechXueXi 仅额外提供给“爱党爱国”且“工作学业繁重”的人
     - 项目开源协议 LGPL-3.0
     - 不得利用本项目盈利
 另外，我们建议你参与一个维护劳动法的项目：
 https://996.icu/ 或 https://github.com/996icu/996.ICU/blob/master/README_CN.md
 TechXueXi 现支持以下模式（答题时请值守电脑旁处理少部分不正常的题目）：
     1 文章+视频
-    2 每日答题+每周答题+专项答题+文章+视频
-      （可以根据当日已得做题积分，及是否有可得分套题，决定是否做题）
-    3 每日答题+文章+视频
+    2 每日答题+文章+视频
       （可以根据当日已得做题积分，决定是否做题）
-''',"=" * 120)
+    3 每日答题+每周答题+专项答题+文章+视频
+      （可以根据当日已得做题积分，及是否有可得分套题，决定是否做题）
+''',"=" * 60)
     TechXueXi_mode = input("请选择模式（输入对应数字）并回车： ")
 
     info_shread = threads.MyThread("获取更新信息...", version.up_info)
@@ -610,20 +625,20 @@ TechXueXi 现支持以下模式（答题时请值守电脑旁处理少部分不�
     #  1 创建用户标记，区分多个用户历史纪录
     dd_status, uname = user.get_user()
     cookies, a_log, v_log, d_log = user_flag(dd_status, uname)
-    total, each = show_score(cookies)
+    total, scores = show_score(cookies)
     nohead, lock, stime = get_argv()
 
-    if TechXueXi_mode in ["2", "3"]:
-        print('开始每日答题……')
-        daily(cookies, d_log, each)
     if TechXueXi_mode in ["2"]:
+        print('开始每日答题……')
+        daily(cookies, d_log, scores)
+    if TechXueXi_mode in ["2", "3"]:
         print('开始每周答题……')
-        weekly(cookies, d_log, each)
+        weekly(cookies, d_log, scores)
         print('开始专项答题……')
-        zhuanxiang(cookies, d_log, each)
+        zhuanxiang(cookies, d_log, scores)
 
-    article_thread = threads.MyThread("文章学习", article, cookies, a_log, each, lock=lock)
-    video_thread = threads.MyThread("视频学习", video, cookies, v_log, each, lock=lock)
+    article_thread = threads.MyThread("文章学习", article, cookies, a_log, scores, lock=lock)
+    video_thread = threads.MyThread("视频学习", video, cookies, v_log, scores, lock=lock)
     article_thread.start()
     video_thread.start()
     article_thread.join()

--- a/SourcePackages/pandalearning.py
+++ b/SourcePackages/pandalearning.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import time
+import math
 from time import sleep
 from sys import argv
 import random
@@ -22,6 +23,7 @@ def user_flag(dd_status, uname):
         if True:
             driver_login = mydriver.Mydriver(nohead=False)
             cookies = driver_login.login()
+            driver_login.quit()
         else:
             cookies = dingding.dd_login_status(uname)
     a_log = user.get_a_log(uname)
@@ -55,7 +57,7 @@ def show_score(cookies):
     total, scores = score.get_score(cookies)
     print("当前学习总积分：" + str(total) + "\t" + "今日得分：" + str(scores["today"]))
     # print("阅读文章:{}/6,观看视频:{}/6,登陆:{}/1,文章时长:{}/6,视频时长:{}/6,每日答题:{}/5,每周答题:{}/5,专项答题:{}/10".format(*ea_ch))
-    print("阅读文章:",scores["article_num"],"/6,观看视频:",scores["video_num"],"/6,登陆:",scores["login"],"/1,文章时长:",scores["article_time"],"/6,视频时长:",scores["video_time"],"/6,每日答题:",scores["daily"],"/6,每周答题:",scores["weekly"],"/5,专项答题:",scores["zhuanxiang"],"/10")
+    print("阅读文章:",scores["article_num"],"/6,观看视频:",scores["video_num"],"/6,登陆:",scores["login"],"/1,文章时长:",scores["article_time"],"/6,视频时长:",scores["video_time"],"/6,每日答题:",scores["daily"],"/5,每周答题:",scores["weekly"],"/5,专项答题:",scores["zhuanxiang"],"/10")
     return total, scores
 
 
@@ -619,7 +621,7 @@ TechXueXi 现支持以下模式（答题时请值守电脑旁处理少部分不�
       （可以根据当日已得做题积分，及是否有可得分套题，决定是否做题）
 ''',"=" * 60)
     TechXueXi_mode = input("请选择模式（输入对应数字）并回车： ")
-
+    
     info_shread = threads.MyThread("获取更新信息...", version.up_info)
     info_shread.start()
     #  1 创建用户标记，区分多个用户历史纪录
@@ -627,14 +629,14 @@ TechXueXi 现支持以下模式（答题时请值守电脑旁处理少部分不�
     cookies, a_log, v_log, d_log = user_flag(dd_status, uname)
     total, scores = show_score(cookies)
     nohead, lock, stime = get_argv()
-
+    
     article_thread = threads.MyThread("文章学习", article, cookies, a_log, scores, lock=lock)
     video_thread = threads.MyThread("视频学习", video, cookies, v_log, scores, lock=lock)
     article_thread.start()
     video_thread.start()
     article_thread.join()
     video_thread.join()
-
+    
     if TechXueXi_mode in ["2"]:
         print('开始每日答题……')
         daily(cookies, d_log, scores)
@@ -643,6 +645,7 @@ TechXueXi 现支持以下模式（答题时请值守电脑旁处理少部分不�
         weekly(cookies, d_log, scores)
         print('开始专项答题……')
         zhuanxiang(cookies, d_log, scores)
-
-    print("总计用时" + str(int(time.time() - start_time) / 60) + "分钟")
+    
+    seconds_used = int(time.time() - start_time)
+    print("总计用时 " + str(math.floor(seconds_used / 60)) + " 分 " + str(seconds_used % 60) + " 秒")
     user.shutdown(stime)

--- a/SourcePackages/pdlearn/get_links.py
+++ b/SourcePackages/pdlearn/get_links.py
@@ -15,9 +15,9 @@ def get_article_links():
             links.append(list[i]["static_page_url"])
         return links
     except:
-        print("=" * 120)
+        print("=" * 60)
         print("get_article_links获取失败")
-        print("=" * 120)
+        print("=" * 60)
         raise
 
 
@@ -31,7 +31,7 @@ def get_video_links():
         link.reverse()
         return link
     except:
-        print("=" * 120)
+        print("=" * 60)
         print("get_video_links获取失败")
-        print("=" * 120)
+        print("=" * 60)
         raise

--- a/SourcePackages/pdlearn/mydriver.py
+++ b/SourcePackages/pdlearn/mydriver.py
@@ -71,9 +71,9 @@ class Mydriver:
             else:
                 self.driver = self.webdriver.Chrome(chrome_options=self.options)
         except:
-            print("=" * 120)
+            print("=" * 60)
             print("Mydriver初始化失败")
-            print("=" * 120)
+            print("=" * 60)
             raise
 
     def login(self):
@@ -165,7 +165,7 @@ class Mydriver:
         return self.driver.find_element_by_xpath(xpath).text
 
     def check_delay(self):
-        delay_time = random.randint(2, 15)
+        delay_time = random.randint(2, 8)
         print('等待 ', delay_time, ' 秒')
         time.sleep(delay_time)
 

--- a/SourcePackages/pdlearn/score.py
+++ b/SourcePackages/pdlearn/score.py
@@ -11,23 +11,37 @@ def get_score(cookies):
         total = requests.get("https://pc-api.xuexi.cn/open/api/score/get", cookies=jar,
                              headers={'Cache-Control': 'no-cache'}).content.decode("utf8")
         total = int(json.loads(total, encoding="utf8")["data"]["score"])
-        each1 = requests.get("https://pc-api.xuexi.cn/open/api/score/today/queryrate", cookies=jar,
+        score_json = requests.get("https://pc-api.xuexi.cn/open/api/score/today/queryrate", cookies=jar,
                              headers={'Cache-Control': 'no-cache'}).content.decode(
             "utf8")
-        each1 = json.loads(each1, encoding="utf8")["data"]["dayScoreDtos"]
-        each1 = [int(i["currentScore"]) for i in each1 if i["ruleId"] in [1, 2, 9, 1002, 1003, 6, 5, 4]]
-        each = [0, 0, 0, 0, 0, 0, 0, 0]
-        each[0] = each1[0]
-        each[1] = each1[1]
-        each[2] = each1[5]
-        each[3] = each1[6]
-        each[4] = each1[7]
-        each[5] = each1[4]
-        each[6] = each1[3]
-        each[7] = each1[2]
-        return total, each
+        dayScoreDtos = json.loads(score_json, encoding="utf8")["data"]["dayScoreDtos"]
+        rule_list = [1, 2, 9, 1002, 1003, 6, 5, 4]
+        score_list= [0, 0, 0, 0   , 0   , 0, 0, 0, 0, 0] # 长度为十
+        for i in dayScoreDtos:
+            for j in range(len(rule_list)):
+                if i["ruleId"] == rule_list[j]:
+                    score_list[j] = int(i["currentScore"])
+        # 阅读文章，视听学习，登录，文章时长，视听学习时长，每日答题，每周答题，专项答题
+        today = 0
+        for i in dayScoreDtos:
+            if(i["ruleId"] == 15 and int(i["currentScore"]) >= 1):
+                today += 1
+            else:
+                today += int(i["currentScore"])
+        scores = {}
+        scores["article_num"]  = score_list[0] # 0阅读文章
+        scores["video_num"]    = score_list[1] # 1视听学习
+        scores["login"]        = score_list[2] # 7登录
+        scores["article_time"] = score_list[3] # 6文章时长
+        scores["video_time"]   = score_list[4] # 5视听学习时长
+        scores["daily"]        = score_list[5] # 2每日答题
+        scores["weekly"]       = score_list[6] # 3每周答题
+        scores["zhuanxiang"]   = score_list[7] # 4专项答题
+        
+        scores["today"]        = today         # 8今日得分
+        return total, scores
     except:
-        print("=" * 120)
+        print("=" * 60)
         print("get_video_links获取失败")
-        print("=" * 120)
+        print("=" * 60)
         raise

--- a/SourcePackages/pdlearn/version.py
+++ b/SourcePackages/pdlearn/version.py
@@ -3,7 +3,7 @@ import requests
 
 def up_info():
     print("\n正在联网获取更新信息...")
-    __Version = "v20200921"
+    __Version = "v20200928"
     __INFO = "TechXueXi最新下载地址为 https://github.com/TechXueXi/TechXueXi"
     try:
         updata_log = requests.get(

--- a/SourcePackages/pdlearn/version.py
+++ b/SourcePackages/pdlearn/version.py
@@ -12,14 +12,14 @@ def up_info():
         updata_log = updata_log.split("\n")
         print(__INFO)
         print("程序版本为：{}，\n最新版本为：{}".format(__Version, updata_log[1].split("=")[1]))
-        print("=" * 120)
+        print("=" * 60)
         if __Version != updata_log[1].split("=")[1]:
             print("当前不是最新版本，建议更新")
-            print("=" * 120)
+            print("=" * 60)
             print("更新提要：")
             for i in updata_log[2:]:
                 print(i)
-        print("=" * 120)
+        print("=" * 60)
         print("更新显示不会打断之前输入等操作，请继续......")
     except:
         print("版本信息网络错误")


### PR DESCRIPTION
- 使用scores重写分数部分，彻底数清楚了各部分的已得分数
- 每行打印60个"="而不是120个，避免太长而变成两行太丑
- "热爱党国" => “爱党爱国”
- 使用css选择器代替xpath并选择时间最久的套题（页面上最后的套题）来做
- 调整看文章看视频顺序，先开启文章视频线程，就可以边看文章视频边做题
- 程序运行时间格式X分X秒
- 登陆后关闭扫码登陆窗口
- 每日答题上限改为5分