### PR TITLE
fix: json loads error in Python 3.9

### DIFF
--- a/SourcePackages/pdlearn/score.py
+++ b/SourcePackages/pdlearn/score.py
@@ -10,11 +10,11 @@ def get_score(cookies):
             jar.set(cookie['name'], cookie['value'])
         total = requests.get("https://pc-api.xuexi.cn/open/api/score/get", cookies=jar,
                              headers={'Cache-Control': 'no-cache'}).content.decode("utf8")
-        total = int(json.loads(total, encoding="utf8")["data"]["score"])
+        total = int(json.loads(total)["data"]["score"])
         score_json = requests.get("https://pc-api.xuexi.cn/open/api/score/today/queryrate", cookies=jar,
                              headers={'Cache-Control': 'no-cache'}).content.decode(
             "utf8")
-        dayScoreDtos = json.loads(score_json, encoding="utf8")["data"]["dayScoreDtos"]
+        dayScoreDtos = json.loads(score_json)["data"]["dayScoreDtos"]
         rule_list = [1, 2, 9, 1002, 1003, 6, 5, 4]
         score_list= [0, 0, 0, 0   , 0   , 0, 0, 0, 0, 0] # 长度为十
         for i in dayScoreDtos:


### PR DESCRIPTION
修复 #39 中描述的问题。

自 Python 3.1开始，`json.loads()` 不再接受 `encoding` 参数。自 Python 3.9 开始，传入该参数会抛出错误。

详见 https://bugs.python.org/issue39377

因为部分 Linux 发行版软件版本较为激进（如 ArchLinux），为避免不必要的重复搜索与解决，因此提出修复。