### PR TITLE
修复获取提示总是获取前题提示导致回答错误的bug

### DIFF
--- a/SourcePackages/pdlearn/mydriver.py
+++ b/SourcePackages/pdlearn/mydriver.py
@@ -211,27 +211,23 @@ class Mydriver:
         # global answer
         content = ""
         try:
-            have_content = 0 #页面上没有加载提示的内容
-            have_content = self.driver.find_element_by_css_selector(".ant-popover")
-        except selenium.common.exceptions.NoSuchElementException as e: #如果是没有加载，点一下查看提示
-            try:
-                # tips_open = self.driver.find_element_by_xpath('//*[@id="app"]/div/div[2]/div/div[4]/div[1]/div[3]/span')
-                tips_open = self.driver.find_element_by_xpath(
-                    '//*[@id="app"]/div/div[*]/div/div[*]/div[*]/div[*]/span[contains(text(), "查看提示")]')
-                tips_open.click()
-                print("有可点击的【查看提示】按钮")
-            except Exception as e:
-                print("没有可点击的【查看提示】按钮")
-                return ""
-            time.sleep(1)
-            try:
-                # tips_open = self.driver.find_element_by_xpath('//*[@id="app"]/div/div[2]/div/div[4]/div[1]/div[3]/span')
-                tips_open = self.driver.find_element_by_xpath(
-                    '//*[@id="app"]/div/div[*]/div/div[*]/div[*]/div[*]/span[contains(text(), "查看提示")]')
-                tips_open.click()
-            except Exception as e:
-                print("关闭查看提示失败！没有可点击的【查看提示】按钮")
-                return ""
+            # tips_open = self.driver.find_element_by_xpath('//*[@id="app"]/div/div[2]/div/div[4]/div[1]/div[3]/span')
+            tips_open = self.driver.find_element_by_xpath(
+                '//*[@id="app"]/div/div[*]/div/div[*]/div[*]/div[*]/span[contains(text(), "查看提示")]')
+            tips_open.click()
+            print("有可点击的【查看提示】按钮")
+        except Exception as e:
+            print("没有可点击的【查看提示】按钮")
+            return ""
+        time.sleep(1)
+        try:
+            # tips_open = self.driver.find_element_by_xpath('//*[@id="app"]/div/div[2]/div/div[4]/div[1]/div[3]/span')
+            tips_open = self.driver.find_element_by_xpath(
+                '//*[@id="app"]/div/div[*]/div/div[*]/div[*]/div[*]/span[contains(text(), "查看提示")]')
+            tips_open.click()
+        except Exception as e:
+            print("关闭查看提示失败！没有可点击的【查看提示】按钮")
+            return ""
         tip_div = self.driver.find_element_by_css_selector(".ant-popover .line-feed")
         tip_full_text = tip_div.get_attribute('innerHTML')
         html = tip_full_text


### PR DESCRIPTION
<!--
感谢你的支持，接下来请填写下方内容，以确保贡献尽快被通过：
-->
## 清单
<!--
在适用的框中以 x 替换空格来勾选。您也可以在创建PR后填写这些内容。如果您不确定其中的任何一个，请随时询问。我们在这里为您提供帮助！
-->

- [ v] 我已经仔细阅读了所有文档的说明
- [v ] 我确认我是以最新版 dev 分支代码为基础编写这个 PR
- [v ] 我确认我这个 PR 仅向 dev 分支提交贡献
- [v ] 我在本地测试过了全部代码

## 说明：
在使用的时候发现专项答题错误率很高，发现总是获取第一题的答案提示，分析了一下是因为切换题目后，加载提示内容并没有更新，删去判断加载提示为空的逻辑后运行正常。
